### PR TITLE
Modify after sign in path for Admins to route to admin namespace

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,12 @@ class ApplicationController < ActionController::Base
       redirect_to passcode_path(student_id: @student)
     end
   end
+
+  def after_sign_in_path_for(resource)
+    if resource.class.name == 'Admin'
+      admin_manage_path
+    else
+      request.env['omniauth.origin'] || stored_location_for(resource) || root_path
+    end
+  end
 end


### PR DESCRIPTION
Admins are now redirected to `admin/manage` page for an overview of student submissions once signed in.