### PR TITLE
Bugfix: Authentication now runs on admin namespace pages

### DIFF
--- a/app/assets/stylesheets/css/pages.scss
+++ b/app/assets/stylesheets/css/pages.scss
@@ -102,3 +102,13 @@ $colorDark: darken($color, 10%) transparent;
     transform: translateX(0);
   }
 }
+
+.tab-content {
+  .pending {
+    color: red;
+  }
+
+  .completed {
+    color: green;
+  }
+}

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -1,5 +1,7 @@
 class Admin::PagesController < ApplicationController
 
+  before_action :authenticate_admin!
+
   def manage
     @students = Student.order(name: :asc)
     @feedback = Feedback.all

--- a/app/views/admin/pages/manage.html.slim
+++ b/app/views/admin/pages/manage.html.slim
@@ -30,7 +30,7 @@
                         span.label.label-danger<> Pending
                       - else
                         span.label.label-success<> Completed
-                    td.text-center = student.feedback_as_reviewer.count
+                    td.text-center class=(pending_teammate_feedback?(student) ? 'pending' : 'completed') = student.feedback_as_reviewer.count
 
         .tab-pane#self
           h1 Self-reflections


### PR DESCRIPTION
- Color-code numbers on overview page based on teammate review count
  - Count turns from red to green when a student completes teammate feedback for their team
- Add Admin authentication to admin pages

🎈 
